### PR TITLE
For now, we show ALL the Android SDK components

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -80,8 +80,9 @@ commands:
       name: Android SDK Tools Version
       pipe: awk -F= '{ print $2 }'
     - command: android list sdk --no-ui --all --extended
-      name: Android installed components
+      name: List of Android SDK components that can be specified in .travis.yml
       pipe: awk -F\" '/^id/ {print $2}' | sort
+    - command: echo 'See http://docs.travis-ci.com/user/languages/android/#How-to-install-Android-SDK-components'
     - command: ant -version
     - command: mvn -version
     - command: gradle -version


### PR DESCRIPTION
The current list include all the available components, not only the ones that are preinstalled.

@BanzaiMan I've started to work on PR that will improve this stuff, but maybe I'll also want to change `travis-build` so that the list of **non-installed + outdated components** is dynmically computed and displayed at the beginning of the build...
