### PR TITLE
Add `xcodebuild -version`

### DIFF
--- a/lib/system_info/config/commands.yml
+++ b/lib/system_info/config/commands.yml
@@ -164,6 +164,10 @@ commands:
 
     - command: sw_vers
       name: Operating System Details
+
+    - command: xcodebuild -version
+      name: Xcode version
+
     - command: uname -r
       name: Darwin Version
 


### PR DESCRIPTION
Though this is implicit when a user chooses `osx_image`, it is nonetheless good to have in the build log.